### PR TITLE
DMZ switch

### DIFF
--- a/Central-router.startup
+++ b/Central-router.startup
@@ -2,5 +2,9 @@
 ip addr add 192.168.0.2/24 dev eth0
 ip link set up dev eth0
 
-# Gateway IP
+# Gateway IP to Internet
 ip route add default via 192.168.0.1 dev eth0
+
+# Gateway IP for DMZ-switch
+ip addr add 10.0.1.1/24 dev eth1
+ip link set up dev eth1

--- a/DMZ-switch.startup
+++ b/DMZ-switch.startup
@@ -1,0 +1,3 @@
+# IP of DMZ-switch
+ip addr add 10.0.1.2/24 dev eth0
+ip link set up dev eth0

--- a/DMZ-switch.startup
+++ b/DMZ-switch.startup
@@ -1,3 +1,6 @@
 # IP of DMZ-switch
 ip addr add 10.0.1.2/24 dev eth0
 ip link set up dev eth0
+
+# Gateway IP to Central-router
+ip route add default via 10.0.1.1 dev eth0

--- a/DMZ-switch/etc/resolvconf/resolv.conf.d/base
+++ b/DMZ-switch/etc/resolvconf/resolv.conf.d/base
@@ -1,0 +1,2 @@
+# hosts external to fido
+nameserver 8.8.8.8

--- a/lab.conf
+++ b/lab.conf
@@ -2,5 +2,6 @@ Internet[0]=Internet
 Internet[1]=Central-router
 
 Central-router[0]=Central-router
+Central-router[1]=DMZ
 
 DMZ-switch[0]=DMZ

--- a/lab.conf
+++ b/lab.conf
@@ -2,3 +2,5 @@ Internet[0]=Internet
 Internet[1]=Central-router
 
 Central-router[0]=Central-router
+
+DMZ-switch[0]=DMZ


### PR DESCRIPTION
Added DMZ-switch for DMZ subnet machines, which helps those machines interact with the Central-router as well as communicate with machines in other subnets.