### PR TITLE
DMZ-subnet

### DIFF
--- a/Central-router.startup
+++ b/Central-router.startup
@@ -2,5 +2,9 @@
 ip addr add 192.168.0.2/24 dev eth0
 ip link set up dev eth0
 
-# Gateway IP
+# Gateway IP to Internet
 ip route add default via 192.168.0.1 dev eth0
+
+# Gateway IP for DMZ-switch
+ip addr add 10.0.1.1/24 dev eth1
+ip link set up dev eth1

--- a/DMZ-switch.startup
+++ b/DMZ-switch.startup
@@ -1,0 +1,3 @@
+# IP of DMZ-switch
+ip addr add 10.0.1.2/24 dev eth0
+ip link set up dev eth0

--- a/DMZ-switch.startup
+++ b/DMZ-switch.startup
@@ -1,3 +1,6 @@
 # IP of DMZ-switch
 ip addr add 10.0.1.2/24 dev eth0
 ip link set up dev eth0
+
+# Gateway IP to Central-router
+ip route add default via 10.0.1.1 dev eth0

--- a/DMZ-switch/etc/resolvconf/resolv.conf.d/base
+++ b/DMZ-switch/etc/resolvconf/resolv.conf.d/base
@@ -1,0 +1,2 @@
+# hosts external to fido
+nameserver 8.8.8.8

--- a/Squid.startup
+++ b/Squid.startup
@@ -1,0 +1,3 @@
+# IP of Squid
+ip addr add 10.0.1.3/24 dev eth0
+ip link set up dev eth0

--- a/Squid.startup
+++ b/Squid.startup
@@ -4,3 +4,8 @@ ip link set up dev eth0
 
 # Route to DMZ-switch
 ip route add default via 10.0.1.2 dev eth0
+
+# Start Squid service
+touch /var/log/squid/access.log
+chmod 777 /var/log/squid/access.log
+systemctl start squid.service

--- a/Squid.startup
+++ b/Squid.startup
@@ -1,3 +1,6 @@
 # IP of Squid
 ip addr add 10.0.1.3/24 dev eth0
 ip link set up dev eth0
+
+# Route to DMZ-switch
+ip route add default via 10.0.1.2 dev eth0

--- a/Squid/etc/resolvconf/resolv.conf.d/base
+++ b/Squid/etc/resolvconf/resolv.conf.d/base
@@ -1,0 +1,2 @@
+# hosts external to fido
+nameserver 8.8.8.8

--- a/Squid/etc/squid/squid.conf
+++ b/Squid/etc/squid/squid.conf
@@ -1,0 +1,5 @@
+acl all src all
+http_access allow all
+http_port 3128 transparent
+http_port 3129
+access_log /var/log/squid/access.log

--- a/lab.conf
+++ b/lab.conf
@@ -8,4 +8,4 @@ Central-router[1]=DMZ
 
 # DMZ subnet
 DMZ-switch[0]=DMZ
-Squid[0]=Squid
+Squid[0]=DMZ

--- a/lab.conf
+++ b/lab.conf
@@ -1,7 +1,11 @@
+# Internet
 Internet[0]=Internet
 Internet[1]=Central-router
 
+# Central-router
 Central-router[0]=Central-router
 Central-router[1]=DMZ
 
+# DMZ subnet
 DMZ-switch[0]=DMZ
+Squid[0]=Squid

--- a/lab.conf
+++ b/lab.conf
@@ -2,5 +2,6 @@ Internet[0]=Internet
 Internet[1]=Central-router
 
 Central-router[0]=Central-router
+Central-router[1]=DMZ
 
 DMZ-switch[0]=DMZ

--- a/lab.conf
+++ b/lab.conf
@@ -2,3 +2,5 @@ Internet[0]=Internet
 Internet[1]=Central-router
 
 Central-router[0]=Central-router
+
+DMZ-switch[0]=DMZ


### PR DESCRIPTION
Added a demilitarised zone, which is a subnet that contains machines to act as a layer of security (or dummies) between the public internet (Internet machine) and the subnets on the internal network. Contains a subnet switch, called DMZ-switch, and the Squid proxy machine.