### PR TITLE
External-subnet

### DIFF
--- a/Central-router.startup
+++ b/Central-router.startup
@@ -8,3 +8,7 @@ ip route add default via 192.168.0.1 dev eth0
 # Gateway IP for DMZ-switch
 ip addr add 10.0.1.1/24 dev eth1
 ip link set up dev eth1
+
+# Gateway IP for External-switch
+ip addr add 10.0.2.1/24 dev eth2
+ip link set up dev eth2

--- a/Ext-DNS.startup
+++ b/Ext-DNS.startup
@@ -4,3 +4,7 @@ ip link set up dev eth0
 
 # Route to External-switch
 ip route add default via 10.0.2.2 dev eth0
+
+# Start DNS service
+chmod +r /etc/dnsmasq_static_hosts.conf
+systemctl start dnsmasq

--- a/Ext-DNS.startup
+++ b/Ext-DNS.startup
@@ -1,3 +1,6 @@
 # IP of Ext-DNS
 ip addr add 10.0.2.4/24 dev eth0
 ip link set up dev eth0
+
+# Route to External-switch
+ip route add default via 10.0.2.2 dev eth0

--- a/Ext-DNS.startup
+++ b/Ext-DNS.startup
@@ -1,0 +1,3 @@
+# IP of Ext-DNS
+ip addr add 10.0.2.4/24 dev eth0
+ip link set up dev eth0

--- a/Ext-DNS/etc/dnsmasq.conf
+++ b/Ext-DNS/etc/dnsmasq.conf
@@ -1,0 +1,10 @@
+interface=eth0
+domain-needed
+bogus-priv
+no-resolv
+no-poll
+address=/doubleclick.net/127.0.0.1
+no-hosts
+addn-hosts=/etc/dnsmasq_static_hosts.conf
+expand-hosts
+domain=example.com

--- a/Ext-DNS/etc/dnsmasq_static_hosts.conf
+++ b/Ext-DNS/etc/dnsmasq_static_hosts.conf
@@ -1,0 +1,2 @@
+201.224.19.7 this.test.com
+201.224.19.7 faceybooky.com

--- a/Ext-DNS/etc/resolvconf/resolv.conf.d/base
+++ b/Ext-DNS/etc/resolvconf/resolv.conf.d/base
@@ -1,0 +1,2 @@
+# hosts external to fido
+nameserver 8.8.8.8

--- a/Ext-Office.startup
+++ b/Ext-Office.startup
@@ -1,0 +1,3 @@
+# IP of Ext-Office
+ip addr add 10.0.2.3/24 dev eth0
+ip link set up dev eth0

--- a/Ext-Office.startup
+++ b/Ext-Office.startup
@@ -1,3 +1,6 @@
 # IP of Ext-Office
 ip addr add 10.0.2.3/24 dev eth0
 ip link set up dev eth0
+
+# Route to External-switch
+ip route add default via 10.0.2.2 dev eth0

--- a/Ext-Office/etc/resolvconf/resolv.conf.d/base
+++ b/Ext-Office/etc/resolvconf/resolv.conf.d/base
@@ -1,0 +1,2 @@
+# hosts external to fido
+nameserver 8.8.8.8

--- a/Ext-WWW.startup
+++ b/Ext-WWW.startup
@@ -4,3 +4,8 @@ ip link set up dev eth0
 
 # Route to External-switch
 ip route add default via 10.0.2.2 dev eth0
+
+# Start apache2 web server
+a2enmod ssl
+a2ensite default-ssl
+systemctl start apache2

--- a/Ext-WWW.startup
+++ b/Ext-WWW.startup
@@ -1,3 +1,6 @@
 # IP of Ext-WWW
 ip addr add 10.0.2.5/24 dev eth0
 ip link set up dev eth0
+
+# Route to External-switch
+ip route add default via 10.0.2.2 dev eth0

--- a/Ext-WWW.startup
+++ b/Ext-WWW.startup
@@ -1,0 +1,3 @@
+# IP of Ext-WWW
+ip addr add 10.0.2.5/24 dev eth0
+ip link set up dev eth0

--- a/Ext-WWW/etc/resolvconf/resolv.conf.d/base
+++ b/Ext-WWW/etc/resolvconf/resolv.conf.d/base
@@ -1,0 +1,2 @@
+# hosts external to fido
+nameserver 8.8.8.8

--- a/Ext-WWW/var/www/index.html
+++ b/Ext-WWW/var/www/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+</head>
+<body>
+<p> This is the EXT-WWW Internal Webserver </p>
+<p> You are now connected to an EXTERNAL host! </p>
+</body>
+</html>

--- a/External-switch.startup
+++ b/External-switch.startup
@@ -1,3 +1,6 @@
 # IP of External-switch
 ip addr add 10.0.2.2/24 dev eth0
 ip link set up dev eth0
+
+# Gateway IP to Central-router
+ip route add default via 10.0.2.1 dev eth0

--- a/External-switch.startup
+++ b/External-switch.startup
@@ -1,0 +1,3 @@
+# IP of External-switch
+ip addr add 10.0.2.2/24 dev eth0
+ip link set up dev eth0

--- a/External-switch/etc/resolvconf/resolv.conf.d/base
+++ b/External-switch/etc/resolvconf/resolv.conf.d/base
@@ -1,0 +1,2 @@
+# hosts external to fido
+nameserver 8.8.8.8

--- a/lab.conf
+++ b/lab.conf
@@ -14,3 +14,4 @@ Squid[0]=DMZ
 # External subnet
 External-switch[0]=External
 Ext-Office[0]=External
+Ext-DNS[0]=External

--- a/lab.conf
+++ b/lab.conf
@@ -5,6 +5,7 @@ Internet[1]=Central-router
 # Central-router
 Central-router[0]=Central-router
 Central-router[1]=DMZ
+Central-router[2]=External
 
 # DMZ subnet
 DMZ-switch[0]=DMZ

--- a/lab.conf
+++ b/lab.conf
@@ -15,3 +15,4 @@ Squid[0]=DMZ
 External-switch[0]=External
 Ext-Office[0]=External
 Ext-DNS[0]=External
+Ext-WWW[0]=External

--- a/lab.conf
+++ b/lab.conf
@@ -9,3 +9,6 @@ Central-router[1]=DMZ
 # DMZ subnet
 DMZ-switch[0]=DMZ
 Squid[0]=DMZ
+
+# External subnet
+External-switch[0]=External

--- a/lab.conf
+++ b/lab.conf
@@ -13,3 +13,4 @@ Squid[0]=DMZ
 
 # External subnet
 External-switch[0]=External
+Ext-Office[0]=External


### PR DESCRIPTION
Added an external zone, which is a subnet that contains external machines which provide outside resources that clients may require. It is within the internal network as the company is hosting it itself. Also gives the admins more control over these machines than if they were directly on the public internet. Contains a subnet switch, called External-switch, Ext-Office, Ext-DNS, and Ext-WWW machines.